### PR TITLE
Update ext4_parse_sb call to reflect AOSP changes

### DIFF
--- a/crypto/fs_mgr/fs_mgr_verity.c
+++ b/crypto/fs_mgr/fs_mgr_verity.c
@@ -140,7 +140,7 @@ static int get_target_device_size(char *blk_device, uint64_t *device_size)
         return -1;
     }
 
-    ext4_parse_sb(&sb);
+    ext4_parse_sb_info(&sb);
     *device_size = info.len;
 
     close(data_device);


### PR DESCRIPTION
ext4_parse_sb in AOSP 5.0 requires file system info to be passed.

Use ext4_parse_sb_info to call with only the superblock

Signed-off-by: Evan Anderson evananderson@aospa.co
