### PR TITLE
cpu temperature: support msm-adc file

### DIFF
--- a/data.cpp
+++ b/data.cpp
@@ -936,18 +936,24 @@ int DataManager::GetMagicValue(const string varName, string& value)
 	   {
 #ifdef TW_CUSTOM_CPU_TEMP_PATH
 		   cpu_temp_file = EXPAND(TW_CUSTOM_CPU_TEMP_PATH);
-		   if (TWFunc::read_file(cpu_temp_file, results) != 0)
+		   if (TWFunc::read_file_firstline(cpu_temp_file, results) != 0)
 			return -1;
 #else
 		   cpu_temp_file = "/sys/class/thermal/thermal_zone0/temp";
-		   if (TWFunc::read_file(cpu_temp_file, results) != 0)
+		   if (TWFunc::read_file_firstline(cpu_temp_file, results) != 0)
 			return -1;
 #endif
-		   convert_temp = strtoul(results.c_str(), NULL, 0) / 1000;
-		   if (convert_temp <= 0)
+		   if (results.compare(0,7,"Result:") == 0) {
+			//msm-adc file
+			convert_temp = strtoul(results.c_str() + 7, NULL, 0);
+		   } else {
 			convert_temp = strtoul(results.c_str(), NULL, 0);
+		   }
+
+		   if (convert_temp >= 1000)
+			convert_temp /= 1000;
 		   if (convert_temp >= 150)
-			convert_temp = strtoul(results.c_str(), NULL, 0) / 10;
+			convert_temp /= 10;
 		   cpuSecCheck = curTime.tv_sec + 5;
 	   }
 	   value = TWFunc::to_string(convert_temp);

--- a/twrp-functions.cpp
+++ b/twrp-functions.cpp
@@ -648,6 +648,20 @@ unsigned int TWFunc::Get_D_Type_From_Stat(string Path) {
 	return DT_UNKNOWN;
 }
 
+int TWFunc::read_file_firstline(string fn, string& results) {
+	ifstream file;
+	file.open(fn.c_str(), ios::in);
+
+	if (file.is_open()) {
+		getline(file, results);
+		file.close();
+		return 0;
+	}
+
+	LOGINFO("Cannot find file %s\n", fn.c_str());
+	return -1;
+}
+
 int TWFunc::read_file(string fn, string& results) {
 	ifstream file;
 	file.open(fn.c_str(), ios::in);

--- a/twrp-functions.hpp
+++ b/twrp-functions.hpp
@@ -68,6 +68,7 @@ public:
 	static unsigned int Get_D_Type_From_Stat(string Path);                      // Returns a dirent dt_type value using stat instead of dirent
 	static timespec timespec_diff(timespec& start, timespec& end);	            // Return a diff for 2 times
 	static int32_t timespec_diff_ms(timespec& start, timespec& end);            // Returns diff in ms
+	static int read_file_firstline(string fn, string& results); //read from file
 	static int read_file(string fn, vector<string>& results); //read from file
 	static int read_file(string fn, string& results); //read from file
 	static int read_file(string fn, uint64_t& results); //read from file


### PR DESCRIPTION
Purpose of this change is to support msm-adc file to read temperature of the cpu.

msm-adc file output something like : "Result: 34 Raw: 8830"

Due to spaces on the output of msm-adc file, we can't use TWFunc::read_file and so I have implemented TWFunc::read_file_firstline.
It should be possible to merge those 2 functions in the futur after deep checks of every functions that are using TWFunc::read_file
