### PR TITLE
 corrected compile errors on presto

### DIFF
--- a/minui/minui.h
+++ b/minui/minui.h
@@ -40,7 +40,6 @@ void gr_fill(int x1, int y1, int x2, int y2);
 
 // system/core/charger uses different gr_print signatures in diferent
 // Android versions, either with or without int bold.
-int gr_text(int x, int y, const char *s, ...);
 int gr_text_impl(int x, int y, const char *s, int bold);
 
  void gr_texticon(int x, int y, gr_surface icon);


### PR DESCRIPTION
system/core/charger uses different gr_print signatures in diferent Android versions, either with or without int bold.We need only int bold or it borks.
