### PR TITLE
correct mount tools

### DIFF
--- a/toybox/Android.mk
+++ b/toybox/Android.mk
@@ -284,6 +284,7 @@ ALL_TOOLS := \
     mktemp \
     modinfo \
     more \
+    mount \
     mountpoint \
     mv \
     netstat \


### PR DESCRIPTION
toybox mount is compatible with buzybox mount, not toolbox mount
