### PR TITLE
correct mount tools and add grep from toybox

### DIFF
--- a/toybox/Android.mk
+++ b/toybox/Android.mk
@@ -262,6 +262,7 @@ ALL_TOOLS := \
     free \
     getenforce \
     getprop \
+    grep \
     groups \
     head \
     hostname \
@@ -284,6 +285,7 @@ ALL_TOOLS := \
     mktemp \
     modinfo \
     more \
+    mount \
     mountpoint \
     mv \
     netstat \


### PR DESCRIPTION
toybox mount is compatible with buzybox mount, not toolbox mount
