### PR TITLE
adbbu: Fix building on omni-5.1 sources

### DIFF
--- a/adbbu/Android.mk
+++ b/adbbu/Android.mk
@@ -31,6 +31,8 @@ ifeq ($(shell test $(PLATFORM_SDK_VERSION) -lt 23; echo $$?),0)
     LOCAL_C_INCLUDES += external/stlport/stlport
 endif
 
+LOCAL_C_INCLUDES += external/zlib
+
 LOCAL_SRC_FILES = \
     libtwadbbu.cpp
 


### PR DESCRIPTION
When compiling get an error:
bootable/recovery/adbbu/libtwadbbu.cpp:24:18: fatal error: zlib.h: No such file or directory
# include <zlib.h>

This patch fixes the problem...
