### PR TITLE
Include getprop and setprop from toolbox for android 7.1

### DIFF
--- a/toolbox/Android.mk
+++ b/toolbox/Android.mk
@@ -213,7 +213,7 @@ ifneq (,$(filter $(PLATFORM_SDK_VERSION), 21 22 23))
     LOCAL_WHOLE_STATIC_LIBRARIES := $(patsubst %,libtoolbox_%,$(BSD_TOOLS))
 endif
 
-ifneq (,$(filter $(PLATFORM_SDK_VERSION), 23 24))
+ifneq (,$(filter $(PLATFORM_SDK_VERSION), 23 24 25))
     # Rule to make getprop and setprop in M trees where toybox normally
     # provides these tools. Toybox does not allow for easy dynamic
     # configuration, so we would have to include the entire toybox binary


### PR DESCRIPTION
Include getprop and setprop for PLATFROM_SDK_VERSION 25 as well as current behaviour leads to no get/setprop.