### PR TITLE
Include Platform SDK 24 in bootloader_message: Missed during test

### DIFF
--- a/bootloader_message/Android.mk
+++ b/bootloader_message/Android.mk
@@ -14,7 +14,7 @@
 
 LOCAL_PATH := $(call my-dir)
 
-ifeq ($(shell test $(PLATFORM_SDK_VERSION) -ge 25; echo $$?),0)
+ifeq ($(shell test $(PLATFORM_SDK_VERSION) -ge 24; echo $$?),0)
     include $(CLEAR_VARS)
     LOCAL_CLANG := true
     LOCAL_SRC_FILES := bootloader_message.cpp


### PR DESCRIPTION
bootloader_message Android.mk missing SDK 24 during test '-gt 25' '-le 23'