### PR TITLE
Prevent kernel panic Android 4.2.2 - Only use usb ffs when usb-ffs directory exist

### DIFF
--- a/etc/ffs-check.sh
+++ b/etc/ffs-check.sh
@@ -1,0 +1,7 @@
+if [ -d "/dev/usb-ffs" ]; then
+   echo "/dev/usb-fss directory found"
+   mkdir /dev/usb-ffs 0770 shell shell
+   mkdir /dev/usb-ffs/adb 0770 shell shell
+   mount functionfs adb /dev/usb-ffs/adb uid=2000,gid=2000
+   write /sys/class/android_usb/android0/f_ffs/aliases adb
+fi

--- a/etc/ffs-check.sh
+++ b/etc/ffs-check.sh
@@ -1,5 +1,5 @@
 if [ -d "/dev/usb-ffs" ]; then
-   echo "/dev/usb-fss directory found"
+   echo "/dev/usb-ffs directory found"
    mkdir /dev/usb-ffs 0770 shell shell
    mkdir /dev/usb-ffs/adb 0770 shell shell
    mount functionfs adb /dev/usb-ffs/adb uid=2000,gid=2000

--- a/etc/init.rc
+++ b/etc/init.rc
@@ -48,10 +48,8 @@ on init
 
 on fs
     mount pstore pstore /sys/fs/pstore
-    mkdir /dev/usb-ffs 0770 shell shell
-    mkdir /dev/usb-ffs/adb 0770 shell shell
-    mount functionfs adb /dev/usb-ffs/adb uid=2000,gid=2000
-
+    exec ffs-check.sh
+    
 on boot
     ifup lo
     hostname localhost

--- a/etc/init.recovery.usb.rc
+++ b/etc/init.recovery.usb.rc
@@ -2,7 +2,6 @@ on fs
     write /sys/class/android_usb/android0/enable 0
     write /sys/class/android_usb/android0/idVendor 18D1
     write /sys/class/android_usb/android0/idProduct D001
-    write /sys/class/android_usb/android0/f_ffs/aliases adb
     write /sys/class/android_usb/android0/functions adb
     write /sys/class/android_usb/android0/iManufacturer ${ro.product.manufacturer}
     write /sys/class/android_usb/android0/iProduct ${ro.product.model}


### PR DESCRIPTION
-Prevents kernel panic for Android 4.2.2

# WE DO NOT MERGE PULL REQUESTS SUBMITTED HERE

You will need to submit it through [OmniRom Gerrit](https://gerrit.omnirom.org/#/admin/projects/android_bootable_recovery/)

For changes to device trees, use [TWRP Gerrit](https://gerrit.twrp.me/)

This guide explani how to use [Gerrit code review](https://forum.xda-developers.com/general/xda-university/guide-using-gerrit-code-review-t3720802)